### PR TITLE
Rock64: Implement HDMI and USB Keyboard, Use U-Boot 2026.04

### DIFF
--- a/boards/pine64-rock64/default.nix
+++ b/boards/pine64-rock64/default.nix
@@ -13,8 +13,7 @@
 
   Tow-Boot = {
     defconfig = "rock64-rk3328_defconfig";
-    uBootVersion = "2024.07";
+    uBootVersion = "2024.10";
     buildUBoot = true;
-    withLogo = false;
   };
 }

--- a/boards/pine64-rock64/default.nix
+++ b/boards/pine64-rock64/default.nix
@@ -1,0 +1,20 @@
+{
+  device = {
+    manufacturer = "PINE64";
+    name = "ROCK64";
+    identifier = "pine64-rock64";
+    productPageURL = "https://www.pine64.org/rock64/";
+  };
+
+  hardware = {
+    soc = "rockchip-rk3328";
+    SPISize = 16 * 1024 * 1024; # 16 MiB
+  };
+
+  Tow-Boot = {
+    defconfig = "rock64-rk3328_defconfig";
+    uBootVersion = "2024.07";
+    buildUBoot = true;
+    withLogo = false;
+  };
+}

--- a/boards/pine64-rock64/default.nix
+++ b/boards/pine64-rock64/default.nix
@@ -14,10 +14,10 @@
   Tow-Boot = {
     defconfig = "rock64-rk3328_defconfig";
     buildUBoot = true;
-    uBootVersion = "2025.01";
+    uBootVersion = "2026.04";
     src = (pkgs.fetchurl {
-          url = "https://ftp.denx.de/pub/u-boot/u-boot-2025.04-rc2.tar.bz2";
-          sha256 = "e54102f17328397d5d63b00865e9108d5806d18018509fc24ce6e7e3fe6a12f1";
+          url = "https://ftp.denx.de/pub/u-boot/u-boot-2026.04.tar.bz2";
+          sha256 = "ac7c04b8b7004923b00a4e5d6699c5df4d21233bac9fda690d8cfbc209fff2fd";
         });
   };
 }

--- a/boards/pine64-rock64/default.nix
+++ b/boards/pine64-rock64/default.nix
@@ -1,4 +1,4 @@
-{
+{ pkgs, ...}: {
   device = {
     manufacturer = "PINE64";
     name = "ROCK64";
@@ -13,7 +13,11 @@
 
   Tow-Boot = {
     defconfig = "rock64-rk3328_defconfig";
-    uBootVersion = "2024.10";
     buildUBoot = true;
+    uBootVersion = "2025.01";
+    src = (pkgs.fetchurl {
+          url = "https://ftp.denx.de/pub/u-boot/u-boot-2025.04-rc2.tar.bz2";
+          sha256 = "e54102f17328397d5d63b00865e9108d5806d18018509fc24ce6e7e3fe6a12f1";
+        });
   };
 }

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -146,6 +146,10 @@ in
             VIDEO_ROCKCHIP = yes;
             DISPLAY_ROCKCHIP_HDMI = yes;
             PHY_ROCKCHIP_INNO_HDMI = yes;
+            BOOTSTD = lib.mkForce yes;
+            BOOTSTD_DEFAULTS = lib.mkForce  yes;
+            DISTRO_DEFAULTS = lib.mkForce  no;
+            BOOTCOMMAND =  lib.mkForce (freeform ''"bootflow scan"'');
           })
         ];
         builder.postPatch =

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -24,12 +24,30 @@ let
   secondOffset = 16384; # in sectors
   sectorSize = 512;
 
-  anyRockchip = lib.any (v: v) [cfg.rockchip-rk3399.enable];
+   rockchipSOCs = [
+    "rockchip-rk3328"
+    "rockchip-rk3399"
+  ];
+
+  anyRockchip = lib.any (soc: config.hardware.socs.${soc}.enable) rockchipSOCs;
   isPhoneUX = config.Tow-Boot.phone-ux.enable;
+  useSpi2K4Kworkaround = cfg.rockchip-rk3399.enable;
+  useSpiSDLayout = cfg.rockchip-rk3328.enable;
+  chipName =
+         if cfg.rockchip-rk3328.enable then "rk3328"
+    else if cfg.rockchip-rk3399.enable then "rk3399"
+    else throw "chipName needs to be defined for SoC."
+  ;
 in
 {
   options = {
     hardware.socs = {
+      rockchip-rk3328.enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable when SoC is Rockchip RK3328";
+        internal = true;
+      };
       rockchip-rk3399.enable = mkOption {
         type = types.bool;
         default = false;
@@ -41,11 +59,9 @@ in
 
   config = mkMerge [
     {
-      hardware.socList = [
-        "rockchip-rk3399"
-      ];
+      hardware.socList = rockchipSOCs;
     }
-    (mkIf cfg.rockchip-rk3399.enable {
+    (mkIf anyRockchip {
       system.system = "aarch64-linux";
       Tow-Boot = {
         config = mkIf withSPI [
@@ -72,13 +88,12 @@ in
           })
         ];
         firmwarePartition = {
-            offset = partitionOffset * 512; # 32KiB into the image, or 64 × 512 long sectors
+            offset = partitionOffset * sectorSize; # 32KiB into the image, or 64 × 512 long sectors
             length = firmwareMaxSize + (secondOffset * sectorSize); # in bytes
           }
         ;
         builder = {
           additionalArguments = {
-            BL31 = "${pkgs.Tow-Boot.armTrustedFirmwareRK3399}/bl31.elf";
             inherit
               firmwareMaxSize
               partitionOffset
@@ -87,12 +102,24 @@ in
             ;
           };
           installPhase = mkMerge [
-            (mkIf (variant == "spi") ''
-              echo ":: Preparing image for SPI flash..."
+            (mkIf (variant == "spi" && useSpi2K4Kworkaround) ''
+              echo ":: Preparing image for SPI flash (2K/4K workaround)..."
               (PS4=" $ "; set -x
-              tools/mkimage -n rk3399 -T rkspi -d tpl/u-boot-tpl-dtb.bin:spl/u-boot-spl-dtb.bin spl.bin
+              tools/mkimage \
+                -n ${chipName} \
+                -T rkspi \
+                -d tpl/u-boot-tpl-dtb.bin:spl/u-boot-spl-dtb.bin spl.bin
               # 512K here is 0x80000 CONFIG_SYS_SPI_U_BOOT_OFFS
               cat <(dd if=spl.bin bs=512K conv=sync) u-boot.itb > $out/binaries/Tow-Boot.$variant.bin
+              )
+            '')
+            (mkIf (variant == "spi" && useSpiSDLayout) ''
+              echo ":: Preparing image for SPI flash (SD layout)..."
+              (PS4=" $ "; set -x
+              dd if=idbloader.img of=Tow-Boot.$variant.bin conv=fsync,notrunc bs=$sectorSize seek=0
+              # 0x80000 here is CONFIG_SYS_SPI_U_BOOT_OFFS
+              dd if=u-boot.itb    of=Tow-Boot.$variant.bin conv=fsync,notrunc bs=$sectorSize seek=$((0x80000 / sectorSize))
+              cp -v Tow-Boot.$variant.bin $out/binaries/
               )
             '')
             (mkIf (variant != "spi") ''
@@ -132,6 +159,14 @@ in
           ''
         ;
       };
+    })
+
+    (mkIf cfg.rockchip-rk3328.enable {
+      Tow-Boot.builder.additionalArguments.BL31 = "${pkgs.Tow-Boot.armTrustedFirmwareRK3328}/bl31.elf";
+    })
+
+    (mkIf cfg.rockchip-rk3399.enable {
+      Tow-Boot.builder.additionalArguments.BL31 = "${pkgs.Tow-Boot.armTrustedFirmwareRK3399}/bl31.elf";
     })
 
     # Documentation fragments

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -141,6 +141,11 @@ in
           (helpers: with helpers; {
             CMD_POWEROFF = yes;
             SYSRESET_CMD_POWEROFF = yes;
+            VIDEO = yes;
+            DISPLAY = yes;
+            VIDEO_ROCKCHIP = yes;
+            DISPLAY_ROCKCHIP_HDMI = yes;
+            PHY_ROCKCHIP_INNO_HDMI = yes;
           })
         ];
         builder.postPatch =

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -176,10 +176,6 @@ in
                             BOOTSTD_FULL = yes;
                             BOOTSTD_DEFAULTS = lib.mkForce yes;
                             DISTRO_DEFAULTS = lib.mkForce no;
-                            BOOTMETH_EXTLINUX = yes; # extlinux.conf (most ARM distros)
-                            BOOTMETH_EFILOADER = yes; # EFI applications
-                            BOOTMETH_EFI_BOOTMGR = yes; # EFI boot manager variables
-                            BOOTMETH_SCRIPT = yes; # boot.scr scripts
                             BOOTCOMMAND = lib.mkForce (freeform ''"bootflow scan"'');
                             USE_BOOTCOMMAND = yes;
 

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -1,203 +1,229 @@
-{ config, lib, pkgs, ... }:
+{
+    config,
+    lib,
+    pkgs,
+    ...
+}:
 
 let
-  inherit (pkgs)
-    fetchpatch
-  ;
-  inherit (lib)
-    mkIf
-    mkMerge
-    mkOption
-    types
-    versionOlder
-    versionAtLeast
-  ;
-  inherit (config.Tow-Boot)
-    variant
-    uBootVersion
-  ;
-  cfg = config.hardware.socs;
-  withSPI = config.hardware.SPISize != null;
+    inherit (pkgs)
+        fetchpatch
+        ;
+    inherit (lib)
+        mkIf
+        mkMerge
+        mkOption
+        types
+        versionOlder
+        versionAtLeast
+        ;
+    inherit (config.Tow-Boot)
+        variant
+        uBootVersion
+        ;
+    cfg = config.hardware.socs;
+    withSPI = config.hardware.SPISize != null;
 
-  firmwareMaxSize = 4 * 1024 * 1024; # MiB in bytes
-  partitionOffset = 64; # in sectors
-  secondOffset = 16384; # in sectors
-  sectorSize = 512;
+    firmwareMaxSize = 4 * 1024 * 1024; # MiB in bytes
+    partitionOffset = 64; # in sectors
+    secondOffset = 16384; # in sectors
+    sectorSize = 512;
 
-   rockchipSOCs = [
-    "rockchip-rk3328"
-    "rockchip-rk3399"
-  ];
+    rockchipSOCs = [
+        "rockchip-rk3328"
+        "rockchip-rk3399"
+    ];
 
-  anyRockchip = lib.any (soc: config.hardware.socs.${soc}.enable) rockchipSOCs;
-  isPhoneUX = config.Tow-Boot.phone-ux.enable;
-  useSpi2K4Kworkaround = cfg.rockchip-rk3399.enable;
-  useSpiSDLayout = cfg.rockchip-rk3328.enable;
-  chipName =
-         if cfg.rockchip-rk3328.enable then "rk3328"
-    else if cfg.rockchip-rk3399.enable then "rk3399"
-    else throw "chipName needs to be defined for SoC."
-  ;
+    anyRockchip = lib.any (soc: config.hardware.socs.${soc}.enable) rockchipSOCs;
+    isPhoneUX = config.Tow-Boot.phone-ux.enable;
+    useSpi2K4Kworkaround = cfg.rockchip-rk3399.enable;
+    useSpiSDLayout = cfg.rockchip-rk3328.enable;
+    chipName =
+        if cfg.rockchip-rk3328.enable then
+            "rk3328"
+        else if cfg.rockchip-rk3399.enable then
+            "rk3399"
+        else
+            throw "chipName needs to be defined for SoC.";
 in
 {
-  options = {
-    hardware.socs = {
-      rockchip-rk3328.enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enable when SoC is Rockchip RK3328";
-        internal = true;
-      };
-      rockchip-rk3399.enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enable when SoC is Rockchip RK3399";
-        internal = true;
-      };
-    };
-  };
-
-  config = mkMerge [
-    {
-      hardware.socList = rockchipSOCs;
-    }
-    (mkIf anyRockchip {
-      system.system = "aarch64-linux";
-      Tow-Boot = {
-        config = mkIf withSPI [
-          (helpers: with helpers; {
-            # SPI boot Support
-            MTD = yes;
-            DM_MTD = yes;
-            ROCKCHIP_SPI_IMAGE = mkIf (versionAtLeast uBootVersion "2022.10") yes;
-            SPI_FLASH_SFDP_SUPPORT = yes;
-            SPL_DM_SPI = yes;
-            SPL_SPI_FLASH_SUPPORT = yes;
-            SPL_SPI_LOAD = yes;
-            SPL_SPI = yes;
-            SPL_SPI_FLASH_TINY = no;
-            SPL_SPI_FLASH_SFDP_SUPPORT = yes;
-            # NOTE: Some boards may have a different value:
-            #   ~/tmp/u-boot/u-boot $ grep -l -R 'u-boot,spl-payload-offset' arch/*/dts/rk*.dts*
-            #    arch/arm/dts/rk3368-lion-haikou-u-boot.dtsi
-            #    arch/arm/dts/rk3399-gru-u-boot.dtsi
-            #    arch/arm/dts/rk3399-puma-haikou-u-boot.dtsi
-            # Not an issue currently.
-            SYS_SPI_U_BOOT_OFFS = freeform ''0x80000''; # 512K
-            SPL_DM_SEQ_ALIAS = yes;
-          })
-        ];
-        firmwarePartition = {
-            offset = partitionOffset * sectorSize; # 32KiB into the image, or 64 × 512 long sectors
-            length = firmwareMaxSize + (secondOffset * sectorSize); # in bytes
-          }
-        ;
-        builder = {
-          additionalArguments = {
-            inherit
-              firmwareMaxSize
-              partitionOffset
-              secondOffset
-              sectorSize
-            ;
-          };
-          installPhase = mkMerge [
-            (mkIf (variant == "spi" && useSpi2K4Kworkaround) ''
-              echo ":: Preparing image for SPI flash (2K/4K workaround)..."
-              (PS4=" $ "; set -x
-              tools/mkimage \
-                -n ${chipName} \
-                -T rkspi \
-                -d tpl/u-boot-tpl-dtb.bin:spl/u-boot-spl-dtb.bin spl.bin
-              # 512K here is 0x80000 CONFIG_SYS_SPI_U_BOOT_OFFS
-              cat <(dd if=spl.bin bs=512K conv=sync) u-boot.itb > $out/binaries/Tow-Boot.$variant.bin
-              )
-            '')
-            (mkIf (variant == "spi" && useSpiSDLayout) ''
-              echo ":: Preparing image for SPI flash (SD layout)..."
-              (PS4=" $ "; set -x
-              dd if=idbloader.img of=Tow-Boot.$variant.bin conv=fsync,notrunc bs=$sectorSize seek=0
-              # 0x80000 here is CONFIG_SYS_SPI_U_BOOT_OFFS
-              dd if=u-boot.itb    of=Tow-Boot.$variant.bin conv=fsync,notrunc bs=$sectorSize seek=$((0x80000 / sectorSize))
-              cp -v Tow-Boot.$variant.bin $out/binaries/
-              )
-            '')
-            (mkIf (variant != "spi") ''
-              echo ":: Preparing single file firmware image for shared storage..."
-              (PS4=" $ "; set -x
-              dd if=idbloader.img of=Tow-Boot.$variant.bin conv=fsync,notrunc bs=$sectorSize seek=$((partitionOffset - partitionOffset))
-              dd if=u-boot.itb    of=Tow-Boot.$variant.bin conv=fsync,notrunc bs=$sectorSize seek=$((secondOffset - partitionOffset))
-              cp -v Tow-Boot.$variant.bin $out/binaries/
-              )
-            '')
-          ];
+    options = {
+        hardware.socs = {
+            rockchip-rk3328.enable = mkOption {
+                type = types.bool;
+                default = false;
+                description = "Enable when SoC is Rockchip RK3328";
+                internal = true;
+            };
+            rockchip-rk3399.enable = mkOption {
+                type = types.bool;
+                default = false;
+                description = "Enable when SoC is Rockchip RK3399";
+                internal = true;
+            };
         };
-      };
-    })
+    };
 
-    (mkIf (anyRockchip) {
-      Tow-Boot = {
-        config = [
-          (helpers: with helpers; {
-            CMD_POWEROFF = yes;
-            SYSRESET_CMD_POWEROFF = yes;
-            VIDEO = yes;
-            DISPLAY = yes;
-            VIDEO_ROCKCHIP = yes;
-            DISPLAY_ROCKCHIP_HDMI = yes;
-            #PHY_ROCKCHIP_INNO_HDMI = yes;
-            BOOTSTD = lib.mkForce yes;
-            BOOTSTD_DEFAULTS = lib.mkForce  yes;
-            DISTRO_DEFAULTS = lib.mkForce  no;
-            BOOTCOMMAND =  lib.mkForce (freeform ''"bootflow scan"'');
-          })
-        ];
-        builder.postPatch =
-          # The baud rate needs to be patched out to match the `CONFIG_BAUDRATE` value,
-          # since this `chosen/stdout-path` value serves as the default if no `console=` param exists.
-          # I don't know if it's possible with the tooling of U-Boot upstream, but if it is, they should sync that.
-          ''
-            echo ':: Patching stdout baud rate in rockchip device trees'
-            (PS4=" $ "
-            for f in arch/arm/dts/*rk3*.dts*; do
-              (set -x
-              sed -i -e 's/serial2:1500000n8/serial2:115200n8/' "$f"
-              )
-            done
-            )
-          ''
-        ;
-      };
-    })
-
-    (mkIf cfg.rockchip-rk3328.enable {
-      Tow-Boot.builder.additionalArguments.BL31 = "${pkgs.Tow-Boot.armTrustedFirmwareRK3328}/bl31.elf";
-      Tow-Boot.builder.postPatch = ''
-        substituteInPlace arch/arm/dts/rk3328-rock64-u-boot.dtsi \
-        --replace rk3328-sdram-lpddr3-1600.dtsi rk3328-sdram-lpddr3-666.dtsi
-      '';
-    })
-
-    (mkIf cfg.rockchip-rk3399.enable {
-      Tow-Boot.builder.additionalArguments.BL31 = "${pkgs.Tow-Boot.armTrustedFirmwareRK3399}/bl31.elf";
-    })
-
-    # Documentation fragments
-    (mkIf (anyRockchip && !isPhoneUX) {
-      documentation.sections.installationInstructions =
-        lib.mkDefault
-        (config.documentation.helpers.genericInstallationInstructionsTemplate {
-          startupConflictNote = ''
-
-            > **NOTE**: The SoC startup order for Rockchip systems will
-            > prefer *SPI*, then *eMMC*, followed by *SD* last.
-            >
-            > You may need to prevent default startup sources from being used
-            > to install using the Tow-Boot installer image.
-
-          '';
+    config = mkMerge [
+        {
+            hardware.socList = rockchipSOCs;
+        }
+        (mkIf anyRockchip {
+            system.system = "aarch64-linux";
+            Tow-Boot = {
+                config = mkIf withSPI [
+                    (
+                        helpers: with helpers; {
+                            # SPI boot Support
+                            MTD = yes;
+                            DM_MTD = yes;
+                            ROCKCHIP_SPI_IMAGE = mkIf (versionAtLeast uBootVersion "2022.10") yes;
+                            SPI_FLASH_SFDP_SUPPORT = yes;
+                            SPL_DM_SPI = yes;
+                            SPL_SPI_FLASH_SUPPORT = yes;
+                            SPL_SPI_LOAD = yes;
+                            SPL_SPI = yes;
+                            SPL_SPI_FLASH_TINY = no;
+                            SPL_SPI_FLASH_SFDP_SUPPORT = yes;
+                            # NOTE: Some boards may have a different value:
+                            #   ~/tmp/u-boot/u-boot $ grep -l -R 'u-boot,spl-payload-offset' arch/*/dts/rk*.dts*
+                            #    arch/arm/dts/rk3368-lion-haikou-u-boot.dtsi
+                            #    arch/arm/dts/rk3399-gru-u-boot.dtsi
+                            #    arch/arm/dts/rk3399-puma-haikou-u-boot.dtsi
+                            # Not an issue currently.
+                            SYS_SPI_U_BOOT_OFFS = freeform "0x80000"; # 512K
+                            SPL_DM_SEQ_ALIAS = yes;
+                        }
+                    )
+                ];
+                firmwarePartition = {
+                    offset = partitionOffset * sectorSize; # 32KiB into the image, or 64 × 512 long sectors
+                    length = firmwareMaxSize + (secondOffset * sectorSize); # in bytes
+                };
+                builder = {
+                    additionalArguments = {
+                        inherit
+                            firmwareMaxSize
+                            partitionOffset
+                            secondOffset
+                            sectorSize
+                            ;
+                    };
+                    installPhase = mkMerge [
+                        (mkIf (variant == "spi" && useSpi2K4Kworkaround) ''
+                            echo ":: Preparing image for SPI flash (2K/4K workaround)..."
+                            (PS4=" $ "; set -x
+                            tools/mkimage \
+                              -n ${chipName} \
+                              -T rkspi \
+                              -d tpl/u-boot-tpl-dtb.bin:spl/u-boot-spl-dtb.bin spl.bin
+                            # 512K here is 0x80000 CONFIG_SYS_SPI_U_BOOT_OFFS
+                            cat <(dd if=spl.bin bs=512K conv=sync) u-boot.itb > $out/binaries/Tow-Boot.$variant.bin
+                            )
+                        '')
+                        (mkIf (variant == "spi" && useSpiSDLayout) ''
+                            echo ":: Preparing image for SPI flash (SD layout)..."
+                            (PS4=" $ "; set -x
+                            dd if=idbloader.img of=Tow-Boot.$variant.bin conv=fsync,notrunc bs=$sectorSize seek=0
+                            # 0x80000 here is CONFIG_SYS_SPI_U_BOOT_OFFS
+                            dd if=u-boot.itb    of=Tow-Boot.$variant.bin conv=fsync,notrunc bs=$sectorSize seek=$((0x80000 / sectorSize))
+                            cp -v Tow-Boot.$variant.bin $out/binaries/
+                            )
+                        '')
+                        (mkIf (variant != "spi") ''
+                            echo ":: Preparing single file firmware image for shared storage..."
+                            (PS4=" $ "; set -x
+                            dd if=idbloader.img of=Tow-Boot.$variant.bin conv=fsync,notrunc bs=$sectorSize seek=$((partitionOffset - partitionOffset))
+                            dd if=u-boot.itb    of=Tow-Boot.$variant.bin conv=fsync,notrunc bs=$sectorSize seek=$((secondOffset - partitionOffset))
+                            cp -v Tow-Boot.$variant.bin $out/binaries/
+                            )
+                        '')
+                    ];
+                };
+            };
         })
-      ;
-    })
-  ];
+
+        (mkIf (anyRockchip) {
+            Tow-Boot = {
+                config = [
+                    (
+                        helpers: with helpers; {
+                            # Enable Poweroff from U-Boot / UEFI
+                            CMD_POWEROFF = yes;
+                            SYSRESET_CMD_POWEROFF = yes;
+
+                            # Enable HDMI Output during boot
+                            VIDEO = yes;
+                            DISPLAY = yes;
+                            VIDEO_ROCKCHIP = yes;
+                            DISPLAY_ROCKCHIP_HDMI = yes;
+                            PHY_ROCKCHIP_INNO_HDMI = yes;
+                            VIDEO_DW_HDMI = yes;
+                            DM_I2C = yes;
+                            VIDEO_BPP32 = yes; # colour depth
+
+                            # Enable USB Keyboard
+                            USB_KEYBOARD = yes;
+
+                            # Use both serial and HDMI/USB Keyboard for UI
+                            SYS_CONSOLE_IS_IN_ENV = yes;
+                            CONSOLE_MUX = yes;
+                            USE_PREBOOT = yes;
+                            PREBOOT = freeform ''"usb start; setenv stdout serial,vidconsole; setenv stderr serial,vidconsole"'';
+
+                            # Auto boot by scanning all devices and boot methods
+                            BOOTSTD = lib.mkForce yes;
+                            BOOTSTD_DEFAULTS = lib.mkForce yes;
+                            DISTRO_DEFAULTS = lib.mkForce no;
+                            BOOTCOMMAND = lib.mkForce (freeform ''"bootflow scan"'');
+
+                        }
+                    )
+                ];
+                builder.postPatch =
+                    # The baud rate needs to be patched out to match the `CONFIG_BAUDRATE` value,
+                    # since this `chosen/stdout-path` value serves as the default if no `console=` param exists.
+                    # I don't know if it's possible with the tooling of U-Boot upstream, but if it is, they should sync that.
+                    ''
+                        echo ':: Patching stdout baud rate in rockchip device trees'
+                        (PS4=" $ "
+                        for f in arch/arm/dts/*rk3*.dts*; do
+                          (set -x
+                          sed -i -e 's/serial2:1500000n8/serial2:115200n8/' "$f"
+                          )
+                        done
+                        )
+                    '';
+            };
+        })
+
+        (mkIf cfg.rockchip-rk3328.enable {
+            Tow-Boot.builder.additionalArguments.BL31 = "${pkgs.Tow-Boot.armTrustedFirmwareRK3328}/bl31.elf";
+            Tow-Boot.builder.postPatch = ''
+                substituteInPlace arch/arm/dts/rk3328-rock64-u-boot.dtsi \
+                --replace rk3328-sdram-lpddr3-1600.dtsi rk3328-sdram-lpddr3-666.dtsi
+            '';
+        })
+
+        (mkIf cfg.rockchip-rk3399.enable {
+            Tow-Boot.builder.additionalArguments.BL31 = "${pkgs.Tow-Boot.armTrustedFirmwareRK3399}/bl31.elf";
+        })
+
+        # Documentation fragments
+        (mkIf (anyRockchip && !isPhoneUX) {
+            documentation.sections.installationInstructions = lib.mkDefault (
+                config.documentation.helpers.genericInstallationInstructionsTemplate {
+                    startupConflictNote = ''
+
+                        > **NOTE**: The SoC startup order for Rockchip systems will
+                        > prefer *SPI*, then *eMMC*, followed by *SD* last.
+                        >
+                        > You may need to prevent default startup sources from being used
+                        > to install using the Tow-Boot installer image.
+
+                    '';
+                }
+            );
+        })
+    ];
 }

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -169,7 +169,7 @@ in
                             SYS_CONSOLE_IS_IN_ENV = yes;
                             CONSOLE_MUX = yes;
                             USE_PREBOOT = yes;
-                            PREBOOT = freeform ''"usb start; setenv stdout serial,vidconsole; setenv stderr serial,vidconsole"'';
+                            PREBOOT = freeform ''"setenv stdout serial,vidconsole; setenv stderr serial,vidconsole"'';
 
                             # Auto boot by scanning all devices and boot methods
                             BOOTSTD = lib.mkForce yes;

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -176,9 +176,8 @@ in
                             BOOTSTD_FULL = yes;
                             BOOTSTD_DEFAULTS = lib.mkForce yes;
                             DISTRO_DEFAULTS = lib.mkForce no;
-                            BOOTCOMMAND = lib.mkForce (freeform ''"bootflow scan"'');
+                            BOOTCOMMAND = lib.mkForce (freeform ''"bootflow scan -b"'');
                             USE_BOOTCOMMAND = yes;
-
                         }
                     )
                 ];

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -173,9 +173,15 @@ in
 
                             # Auto boot by scanning all devices and boot methods
                             BOOTSTD = lib.mkForce yes;
+                            BOOTSTD_FULL = yes;
                             BOOTSTD_DEFAULTS = lib.mkForce yes;
                             DISTRO_DEFAULTS = lib.mkForce no;
+                            BOOTMETH_EXTLINUX = yes; # extlinux.conf (most ARM distros)
+                            BOOTMETH_EFILOADER = yes; # EFI applications
+                            BOOTMETH_EFI_BOOTMGR = yes; # EFI boot manager variables
+                            BOOTMETH_SCRIPT = yes; # boot.scr scripts
                             BOOTCOMMAND = lib.mkForce (freeform ''"bootflow scan"'');
+                            USE_BOOTCOMMAND = yes;
 
                         }
                     )

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -145,7 +145,7 @@ in
             DISPLAY = yes;
             VIDEO_ROCKCHIP = yes;
             DISPLAY_ROCKCHIP_HDMI = yes;
-            PHY_ROCKCHIP_INNO_HDMI = yes;
+            #PHY_ROCKCHIP_INNO_HDMI = yes;
             BOOTSTD = lib.mkForce yes;
             BOOTSTD_DEFAULTS = lib.mkForce  yes;
             DISTRO_DEFAULTS = lib.mkForce  no;
@@ -172,6 +172,10 @@ in
 
     (mkIf cfg.rockchip-rk3328.enable {
       Tow-Boot.builder.additionalArguments.BL31 = "${pkgs.Tow-Boot.armTrustedFirmwareRK3328}/bl31.elf";
+      Tow-Boot.builder.postPatch = ''
+        substituteInPlace arch/arm/dts/rk3328-rock64-u-boot.dtsi \
+        --replace rk3328-sdram-lpddr3-1600.dtsi rk3328-sdram-lpddr3-666.dtsi
+      '';
     })
 
     (mkIf cfg.rockchip-rk3399.enable {

--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -84,7 +84,7 @@ in
       # -----
 
       # Ensures white text on black background
-      SYS_WHITE_ON_BLACK = yes;
+      SYS_WHITE_ON_BLACK = if withLogo then yes else no;
 
       # Ensures we're not using Truetype
       CONSOLE_TRUETYPE = no;

--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -84,7 +84,7 @@ in
       # -----
 
       # Ensures white text on black background
-      SYS_WHITE_ON_BLACK = if withLogo then yes else no;
+      SYS_WHITE_ON_BLACK = yes;
 
       # Ensures we're not using Truetype
       CONSOLE_TRUETYPE = no;

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -79,6 +79,7 @@ in
           "2024.01" = "sha256-uZYR8e0je/NUG9yENLaMlqbgWWcGH5kkQ8swqr6+9bM=";
           "2024.04" = "sha256-GKhT/jn6160DqQzC1Cda6u1tppc13vrDSSuAUIhD3Uo=";
           "2024.07" = "sha256-9ZHamrkO89az0XN2bQ3f+QxO1zMGgIl0hhF985DYPI8=";
+          "2024.10" = "sha256-so2vSsF+QxVjYweL9RApdYQTf231D87ZsS3zT2GpL7A=";
         };
         Tow-Boot = {
           "tb-2023.07-007" = "sha256-qEVvvnKy3fdFmU7Qn1U2PMqhf8p228v6+4XtkVGgQgk=";

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -78,6 +78,7 @@ in
           "2023.10" = "sha256-4A5sbwFOBGEBc50I0G8yiBHOvPWuEBNI9AnLvVXOaQA=";
           "2024.01" = "sha256-uZYR8e0je/NUG9yENLaMlqbgWWcGH5kkQ8swqr6+9bM=";
           "2024.04" = "sha256-GKhT/jn6160DqQzC1Cda6u1tppc13vrDSSuAUIhD3Uo=";
+          "2024.07" = "sha256-9ZHamrkO89az0XN2bQ3f+QxO1zMGgIl0hhF985DYPI8=";
         };
         Tow-Boot = {
           "tb-2023.07-007" = "sha256-qEVvvnKy3fdFmU7Qn1U2PMqhf8p228v6+4XtkVGgQgk=";

--- a/modules/u-boot.nix
+++ b/modules/u-boot.nix
@@ -31,7 +31,7 @@ mkIf config.Tow-Boot.buildUBoot
     # sunxi: Use mmc_get_env_dev only if relevant
     (tbPatch "e1d686d0591e8fa95d5218d965ec3b0aa83c5d27" "sha256-u3LVyKJvx5QDMJig+blFF1nGnSbVdCEI7zDx8HvHBfA=")
   ]
-  ++ optionals (versionAtLeast uBootVersion "2023.01") [
+  ++ optionals (versionAtLeast uBootVersion "2023.01" && versionOlder uBootVersion "2023.10") [
     # sunxi: Use mmc_get_env_dev only if relevant
     (tbPatch "eb193c32c471a829a0b81c6a94f9bb9b9e392fb3" "sha256-K7p8gDJwoaTMdVgvfXC2l/u6dxnIoEBrD+yoXpvY3EY=")
   ]

--- a/support/overlay/overlay.nix
+++ b/support/overlay/overlay.nix
@@ -54,6 +54,7 @@ in
 
     inherit (callPackage ./arm-trusted-firmware { })
       armTrustedFirmwareAllwinner
+      armTrustedFirmwareRK3328
       armTrustedFirmwareRK3399
       armTrustedFirmwareS905
       armTrustedFirmwareTools


### PR DESCRIPTION
Uboot mainline now has support for HDMI video and USB Keyboard. This is a proof of concept built using upstream U-Boot 2026.04. Hopefully, it should now be far easier to integrate into tow-boot